### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# ssl
+nginx/certs/cert.pem
+nginx/certs/key.pem
+
 # database
 data/


### PR DESCRIPTION
This PR intends to hide the keys used in the sll certification.